### PR TITLE
GA: Set Sample Rate to 50%

### DIFF
--- a/views/components/GoogleAnalytics.jsx
+++ b/views/components/GoogleAnalytics.jsx
@@ -11,7 +11,7 @@ var GoogleAnalytics = React.createClass({
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '${propertyId}', 'auto');
+    ga('create', '${propertyId}', 'auto', {'sampleRate': 50});
 
     </script>
     `;


### PR DESCRIPTION
:eyeglasses: @ajacksified 

https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#sampleRate

(Auto appears to come from: https://developers.google.com/analytics/devguides/collection/analyticsjs/method-reference)
